### PR TITLE
Removed inconsistent required leading slash for directory path

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,6 +1,6 @@
 module.exports =
 {
-  directory : '/public',
+  directory : 'public',
   contentTypeMapper :
   {
     '.jpg'  : 'image/jpeg',

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = class extends require('@superhero/core/controller/dispatcher')
     {
       const
       pathname  = this.request.url.pathname,
-      resource  = base + config.directory + path.normalize(pathname),
+      resource  = base + '/' + config.directory + path.normalize(pathname),
       extension = path.extname(resource).toLowerCase(),
       headers   = { 'Content-Type' : config.contentTypeMapper[extension] },
       body      = await readFile(resource, 'utf-8')


### PR DESCRIPTION
Any other component of js.core doesn't require to have a leading slash for path properties on the config being this the only component that requires to do so which is inconsistent with the rest of the js.core ecosystem.